### PR TITLE
Create: BOJ_13702 이상한 술집 code

### DIFF
--- a/src/hanabzu/BOJ_13702_WeirdHof/main.cpp
+++ b/src/hanabzu/BOJ_13702_WeirdHof/main.cpp
@@ -25,7 +25,7 @@ int main() {
 
 	/* find upper bound */
 	unsigned int low = 0;
-	unsigned int high = max + 1; // !! IDNW must do +1 to a maximum volume !!
+	unsigned int high = max + 1; // !! IDKW must do +1 to a maximum volume !!
 	unsigned int mid = 0;
 
 	while (low < high) {

--- a/src/hanabzu/BOJ_13702_WeirdHof/main.cpp
+++ b/src/hanabzu/BOJ_13702_WeirdHof/main.cpp
@@ -23,12 +23,12 @@ int main() {
 		max = (max < v[i]) ? v[i] : max;
 	}
 
-	/* find upper bound */
+	/* find upper bound - 1 */
 	unsigned int low = 0;
-	unsigned int high = max + 1; // !! IDKW must do +1 to a maximum volume !! -> Because of UPPER BOUND!
+	unsigned int high = max;
 	unsigned int mid = 0;
 
-	while (low < high) {
+	while (low <= high) {
 		p = 0;
 		mid = (high + low) >> 1;
 		if (mid != 0) {
@@ -40,12 +40,11 @@ int main() {
 			low = mid + 1;
 		}
 		else {
-			high = mid;
+			high = mid - 1;
 		}
 	}
 
-	/* answer is upper bound minus 1, so as low minus 1 */
-	cout << (low == 0 ? low : --low); //prevent underflow
+	cout << high;
 	return 0;
 }
 

--- a/src/hanabzu/BOJ_13702_WeirdHof/main.cpp
+++ b/src/hanabzu/BOJ_13702_WeirdHof/main.cpp
@@ -25,7 +25,7 @@ int main() {
 
 	/* find upper bound */
 	unsigned int low = 0;
-	unsigned int high = max + 1; // !! IDKW must do +1 to a maximum volume !!
+	unsigned int high = max + 1; // !! IDKW must do +1 to a maximum volume !! -> Because of UPPER BOUND!
 	unsigned int mid = 0;
 
 	while (low < high) {

--- a/src/hanabzu/BOJ_13702_WeirdHof/main.cpp
+++ b/src/hanabzu/BOJ_13702_WeirdHof/main.cpp
@@ -1,0 +1,53 @@
+/* hanabzu */
+#include <iostream>
+#include <vector>
+using namespace std;
+
+int main() {
+	ios_base::sync_with_stdio(false);
+	cin.tie(NULL);
+	cout.tie(NULL);
+
+	int n, k, p = 0; // p is # of people who can receive makgeolli
+	cin >> n;
+	cin >> k;
+
+	vector<unsigned int> v(n); // volumes of makgeolli
+	unsigned int t; // a temp volume for read input
+	unsigned int max = 0;
+
+	/* read volumes */
+	for (int i = 0; i < n; i++) {
+		cin >> t;
+		v[i] = t;
+		max = (max < v[i]) ? v[i] : max;
+	}
+
+	/* find upper bound */
+	unsigned int low = 0;
+	unsigned int high = max + 1; // !! IDNW must do +1 to a maximum volume !!
+	unsigned int mid = 0;
+
+	while (low < high) {
+		p = 0;
+		mid = (high + low) >> 1;
+		if (mid != 0) {
+			for (int i = 0; i < n; i++) {
+				p += v[i] / mid; // count # of people who can receive
+			}
+		}
+		if (p >= k) {
+			low = mid + 1;
+		}
+		else {
+			high = mid;
+		}
+	}
+
+	/* answer is upper bound minus 1, so as low minus 1 */
+	cout << (low == 0 ? low : --low); //prevent underflow
+	return 0;
+}
+
+
+


### PR DESCRIPTION
-------------------------------------------
###  **Upper Bound Binary Search**
-------------------------------------------

> - 모든 입력을 받은 후 `0 ~ max+1` 사이의 정수에서 Upper bound를 구합니다.
> - Upper bound를 구할 때에는 모든 막걸리 주전자(`vector v`)를 돌며 현재 주려는 막걸리양(`mid`)로 줄 수 있는 인원수(`p`)를 구합니다.
> - 이 때 `p`를 `k`와 비교하며 이분 탐색해 Upper bound를 찾습니다.
> - 여기서 Upper bound는 `한 사람에게 주는 막걸리의 최대치 + 1`입니다.  
> - 즉 구해지는 Upper bound부터 딱 막걸리가 부족하게 됩니다.
> - 그러므로 답을 제출할 때는 구해낸 Upper bound인 `low`에서 `-1`합니다. 
>   (이 때, 답이 `0`인 경우` unsigned int`인 `low`에서 underflow가 발생하므로 예외 처리함)
> 
> > 처음엔 `high = max`로 두고 풀었는데 이 때 `max`가 답이어야 하는 경우(ex input : `2 2 2 2`, `3 3 4 4 4`)에 결과가 정답보다 1이 적게 구해지는 오류가 생겼습니다. (ex: 인풋이 `3 3 4 4 4` 인 경우 `4`가 출력돼야 하지만 `3`이 출력)
> > `high = max+1` 로 시작하여 해결하였지만 정확한 이유는 잘 모르겠습니다.
> 
> - 해결됨 -> Upper bound를 구하는 것이기 때문임.

+ `high`를 결과값으로 선택하는 방법으로 수정, 즉 `high`가 Upper bound - 1 인 값임.