### PR TITLE
Create: BOJ 13702 이상한 술집

### DIFF
--- a/src/leejaeyeong/이진탐색/BOJ_13702_이상한술집.java
+++ b/src/leejaeyeong/이진탐색/BOJ_13702_이상한술집.java
@@ -1,0 +1,47 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class BOJ_13702_이상한술집 {
+	static int  n, k;
+	static int[] arr;
+	public static void main(String[] args) throws Exception {
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		n = stoi(st.nextToken()); // 막걸리 수
+		k = stoi(st.nextToken()); // 인원 수
+		arr = new int[n];
+		for (int i = 0; i < n; i++) {
+			arr[i] = stoi(br.readLine());
+		}
+		System.out.println(binarySearch(0, Integer.MAX_VALUE)); // 최적 용량 범위 
+	}
+
+	private static int binarySearch(long min, long max) {
+		if (min > max) {
+			return (int) max; // 최적 용량 반환
+		}
+		
+		long mid = (min + max) / 2;
+		if (mid != 0 && solve(mid)) min = mid + 1;
+		else max = mid - 1;
+		
+		return binarySearch(min, max);
+	}
+	
+	private static boolean solve(long amount) {
+		int count = 0;
+		for (int i = 0; i < n; i++) {
+			count += arr[i] / amount; 
+			if (count >= k) // k명 이상 나눠줄 수 있는 경우 
+				return true;
+		}
+		return false;
+	}
+
+	private static int stoi(String s) {
+		return Integer.parseInt(s);
+	}
+}


### PR DESCRIPTION
### 이진탐색 적용
---
####  단순 반복 접근할 경우 
 - 모든 사람들에게 최대의 용량으로 막걸리를 주는 경우를 계산하면 O(n)의 시간 복잡도를 가지고, naive하게 1초에 1억번 정도의 연산이 가능하므로 이 방법은 **시간초과**가 발생합니다.
#### 이진탐색으로 해결
 - 단순 반복에 비해 효율적으로 값을 탐색할 수 있는 **이진탐색을 적용**하여 해결했습니다. 
 - mid를 구하는 과정에서 overflow로 인해 일부 테스트케이스가 틀렸는데 자료형을 `long`으로 바꿔서 해결했습니다.
 - 이진탐색 알고리즘은 반복과 재귀를 이용한 구현이 가능한데, 저는 재귀적인 방법을 사용했습니다. (필요 이상으로 스택 메모리를 사용한다는 단점이 있지만 저는 이 방법이 깔끔해보이고 편한 것 같네요^^)