### PR TITLE
Create: BOJ_2980_RoadandLight 코드

### DIFF
--- a/src/hanabzu/BOJ_2980_RoadandLight/main.cpp
+++ b/src/hanabzu/BOJ_2980_RoadandLight/main.cpp
@@ -1,0 +1,48 @@
+/* hanabzu */
+#include <iostream>
+using namespace std;
+
+int main() {
+	ios_base::sync_with_stdio(false);
+	cin.tie(NULL);
+	cout.tie(NULL);
+
+	int N,L, rest = 0; 
+	cin >> N;
+	cin >> L;
+
+	int light[100][3];
+	
+	// read data
+	for (int i = 0; i < N; i++) {
+		cin >> light[i][0] >> light[i][1] >> light[i][2];	
+	}
+	
+	// rest is a distance between last traffic light and the goal
+	rest = L - light[N-1][0];
+
+	// let D as a distance from pre-traffic light
+	for (int i = N - 1; i > 0; i--) {
+		light[i][0] -= light[i - 1][0];
+	}
+
+	int time = 0;
+	int statement; // traffic light's statement
+	for (int i = 0; i < N; i++) {
+		time += light[i][0];
+		statement = time % (light[i][1] + light[i][2]);
+		if (statement < light[i][1]) { // if red light, plus a waiting time for green light
+			time += (light[i][1] - statement);
+		}
+	}
+
+	// go to the goal
+	time += rest;
+
+	cout << time;
+
+	return 0;
+}
+
+
+


### PR DESCRIPTION
input을 2차원 배열에 읽고, 계산의 편리함을 위해서 `D`가 출발점에서 신호등까지의 거리로 되어있는 것을 **이전 신호등에서 현재 신호등까지의 거리**로 수정합니다. 또한 **마지막 신호등에서 끝점까지의 거리**도 구해둡니다.
`time = 0`에서 시작하여 각 루프마다 먼저 `D`를 더합니다.
그 후 `statement = time % (light[i][1] + light[i][2])` 로 `statement`에 **현재 신호등의 상황**을 저장합니다.
만약 `statement < R` 이라면 현재 빨간불이므로 파란불까지 남은 시간을 `time`에 더해줍니다.
루프가 끝나면 마지막 신호등에서 출발했다는 뜻이므로 끝점까지의 거리인 `rest`를 `time`에 더해줍니다.

