### PR TITLE
Create: BOJ_10434_행복한소수 source code

### DIFF
--- a/src/hanabzu/BOJ_10434_행복한소수/main.cpp
+++ b/src/hanabzu/BOJ_10434_행복한소수/main.cpp
@@ -1,0 +1,74 @@
+/* hanabzu */
+/* BOJ_10434 행복한 소수 */
+
+#include <iostream>
+#include <set>
+#include <string>
+#include <cmath>
+
+using namespace std;
+
+int sumDigitsSquare(int n);
+bool isHappy(int n);
+bool isPrime(int n);
+
+set<int> happyNums; // save happy numbers
+
+int main() {
+	ios_base::sync_with_stdio(false);
+	cin.tie(NULL);
+	cout.tie(NULL);
+
+	int P, N, M;
+	string result;
+
+	cin >> P;
+
+	for (int i = 0; i < P; i++) {
+		cin >> N >> M;
+		result = isHappy(M) && isPrime(M) ? " YES\n" : " NO\n";
+		cout << N << ' ' << M << result;
+	}
+}
+
+int sumDigitsSquare(int n) {
+	int sum = 0;
+	string str_n = to_string(n);
+	for (int i = 0; i < str_n.length(); i++) {
+		sum += pow((str_n[i] - '0'), 2);
+	}
+	return sum;
+}
+
+bool isHappy(int n) {
+	int sum = n;
+	set<int> candidates; // potential numbers
+
+	while (sum != 1) {
+		if (happyNums.count(sum)) { // it's already happy!
+			break;
+		}
+
+		if (candidates.count(sum)) { // loop! it will never be happy...
+			return false;
+		}
+
+		candidates.insert(sum);
+		sum = sumDigitsSquare(sum);
+	}
+
+	happyNums.insert(candidates.begin(), candidates.end()); // save it!
+	return true;
+}
+
+bool isPrime(int n) {
+	if (n == 1) {
+		return false;
+	}
+	for (int i = 2; i * i <= n; i++) {
+		if (n % i == 0) {
+			return false;
+		}
+	}
+	return true;
+}

--- a/src/hanabzu/BOJ_10434_행복한소수/main.cpp
+++ b/src/hanabzu/BOJ_10434_행복한소수/main.cpp
@@ -26,7 +26,7 @@ int main() {
 
 	for (int i = 0; i < P; i++) {
 		cin >> N >> M;
-		result = isHappy(M) && isPrime(M) ? " YES\n" : " NO\n";
+		result = isPrime(M) && isHappy(M) ? " YES\n" : " NO\n";
 		cout << N << ' ' << M << result;
 	}
 }


### PR DESCRIPTION
## Implementation using STL set data structure and  Dynamic Programming (Maybe...?)

### 행복한 수 판별하기
STL 자료형인 set을 사용해 계산 과정에서 나오는 수들을 `set<int> candidates`에 저장하고, 현재 계산된 결과가 1이거나, 전역변수 `set<int> happyNums`에 이미 저장된 행복한 수 이거나, 이미 이전에 나왔던 수일 때까지 반복하는 방법을 사용했습니다.
만약 계산된 값이 1이거나 `happyNums`에 존재한다면 맨 처음 숫자부터 지금까지 온 숫자들은 모두 행복한 수입니다.
그러므로 지금까지 `candidates`에 저장된 수들을 전역변수로 선언된 `happyNums`에 추가합니다.
그렇기 때문에 만약 다른 M에 대해서 연산을 하다가도 예를들어 어떤 수의 계산과정에서 72가 되었다고 한다면, 이 다음 수는 53일 것입니다. 또 다른 수의 계산과정에서 27이 되었다면 이 다음수도 53이 될 것이고, 만약  72와 27 중 어느 하나가 행복한 수에 도달하게 된다면 다른 한 수도 반드시 행복한 수가 되게 됩니다.
그렇지만 이 아이디어로 계산수를 줄일 수 있다고 생각했는데 이 모듈을 빼고 테스트해도 시간에는 차이가 없었습니다.
이유로는 아무래도 생각보다 겹치는 경우가 적어서 오히려 `happyNums`의 값들과 비교하는 과정의 실행 시간 추가로 크게 reduce되진 못한 것 같습니다.
만약 계산 반복 중에 1이 되지 못하고 이미 `candidates`에 존재하는 숫자가 다시 등장한다면, 이 숫자는 무한 루프를 돌게되므로 행복한 수가 아닙니다.


### 소수 판별하기
소수 판별은 n에 대해 2부터 sqrt(n)까지 modular를 구하는 것으로 간단하게 알 수 있습니다.


### 추가 커밋
 판별할 때 행복한 수인지보다 소수인지를 먼저 판별하는 것이 실행 시간이 빠르게 나왔습니다. (12ms->4ms)

