### PR TITLE
Create: Softeer_복잡한 조립라인2 code

### DIFF
--- a/src/ashpurple/Softeer_복잡한 조립라인2/Main.java
+++ b/src/ashpurple/Softeer_복잡한 조립라인2/Main.java
@@ -17,7 +17,7 @@ public class Main {
 		int workNum = stoi(st.nextToken()); // the number of work place
 		
 		int[] workTime = new int[lineNum];
-		int[] moveTime = new int[workNum-1];
+		int moveTime;
 		int previousMin=0;
 		Arrays.fill(workTime, 0); // initialize workTime
 		
@@ -28,8 +28,8 @@ public class Main {
 				workTime[j] = min(previousMin, workTime[j]);
 				workTime[j] += stoi(st.nextToken()); // update workTime
 			}
-			moveTime[i] = stoi(st.nextToken());
-			previousMin = min(workTime)+moveTime[i]; // previous minimum workTime
+			moveTime = stoi(st.nextToken());
+			previousMin = min(workTime)+moveTime; // previous minimum workTime
 		}
 		st = new StringTokenizer(br.readLine()); // last line
 		for (int j = 0; j < lineNum; j++) {

--- a/src/ashpurple/Softeer_복잡한 조립라인2/Main.java
+++ b/src/ashpurple/Softeer_복잡한 조립라인2/Main.java
@@ -1,0 +1,62 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+import java.util.Arrays;
+
+public class Main {
+
+	public static void main(String[] args) throws Exception {
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		int lineNum = stoi(st.nextToken()); // the number of line
+		int workNum = stoi(st.nextToken()); // the number of work place
+		
+		int[] workTime = new int[lineNum];
+		int[] moveTime = new int[workNum-1];
+		int previousMin=0;
+		Arrays.fill(workTime, 0); // initialize workTime
+		
+		/* input */
+		for(int i = 0; i < workNum-1; i++) {
+			st = new StringTokenizer(br.readLine());
+			for (int j = 0; j < lineNum; j++) {
+				workTime[j] = min(previousMin, workTime[j]);
+				workTime[j] += stoi(st.nextToken()); // update workTime
+			}
+			moveTime[i] = stoi(st.nextToken());
+			previousMin = min(workTime)+moveTime[i]; // previous minimum workTime
+		}
+		st = new StringTokenizer(br.readLine()); // last line
+		for (int j = 0; j < lineNum; j++) {
+			workTime[j] = min(previousMin, workTime[j]);
+			workTime[j] += stoi(st.nextToken());
+		}
+		/* output */
+		String result=String.valueOf(min(workTime));
+		bw.write(result);
+		bw.flush();
+		bw.close();
+	}
+	public static int min(int n[]) {
+	    int min = n[0];
+	    for (int i = 1; i < n.length; i++)
+	      if (n[i] < min) 
+	    	  min = n[i];
+	    return min;
+	}
+	private static int min(int X, int Y) {
+		if(X > Y)
+			return Y;
+		else
+			return X;
+	}
+	private static int stoi(String s) {
+		return Integer.parseInt(s);
+	}
+	
+}


### PR DESCRIPTION
K개의 라인이 있을 때 한 작업장에서 다음 작업장으로 가는 경우의 수를 단순 계산 할 시
다음 하나의 작업에서는 K개의  값을 비교해서 가장 작은 값을 가져와야하고 다음 작업장 또한 K개이므로
총 K^2 의 경우의 수가 발생합니다. 이를 또 작업장의 개수만큼(N) 반복하므로 총 `O(N*K^2)`의 시간이 걸립니다.

하지만 단위마다 작업장을 교체하는 시간이 같으므로 불필요한 계산을 피할 수 있습니다.
먼저 한 단위의 작업장을 입력받아 **최소값을 저장**(`previousMin = min(workTime)+moveTime[i]`)하게 되면 
다음 작업장에선 두 개의 값만 비교(`min(previousMin, workTime[j])`) 하므로 총 시간을 `O(N*K)`로 줄일 수 있습니다.

또한 계산과정이 greedy적이기 때문에 메모리 낭비를 줄이고자 입력을 받으며 계산하였습니다.