### PR TITLE
Create: BOJ_7569_토마토

### DIFF
--- a/src/hanabzu/BOJ_6568_귀도반로썸은크리스마스날심심하다고파이썬을만들었다/main.cpp
+++ b/src/hanabzu/BOJ_6568_귀도반로썸은크리스마스날심심하다고파이썬을만들었다/main.cpp
@@ -50,7 +50,6 @@ void read_case() {
 			if (adder == 0) {
 				pc = address;
 			}
-			break;
 		case 3: // NOP
 			break;
 		case 4: // DEC

--- a/src/hanabzu/BOJ_7569_토마토/main.cpp
+++ b/src/hanabzu/BOJ_7569_토마토/main.cpp
@@ -1,0 +1,87 @@
+﻿/* hanabzu */
+/* BOJ_7569 토마토 */
+
+#include <iostream>
+#include <algorithm>
+#include <queue>
+#include <utility>
+
+using namespace std;
+
+int M, N, H, num_tomatoes, ripe = 0, day = 0;
+int box[102][102][102]; // box[H][M][N]
+int dir[6][3] = { {1,0,0},{-1,0,0},{0,1,0},{0,-1,0},{0,0,1},{0,0,-1} };
+queue<pair<int,pair<int,int>>> q; // {H,M,N}
+
+void print_tomatoes(); // for debugging
+
+int main() {
+	ios_base::sync_with_stdio(false);
+	cin.tie(NULL);
+	cout.tie(NULL);
+
+	cin >> M >> N >> H;
+
+	num_tomatoes = M * N * H;
+
+	// padding
+	for (int i = 1; i <= H ; i++) {
+		for (int j = 1; j <= N; j++) {
+			for (int k = 1; k <= M; k++) {
+				cin >> box[i][k][j];
+				if (box[i][k][j] == -1) {
+					num_tomatoes--;
+				}
+				if (box[i][k][j] == 1) {
+					q.push(pair<int, pair<int, int>>(i,pair<int,int>(k,j)));
+					ripe++;
+				}
+				box[i][k][j]++;
+			}
+		}
+	}
+
+	// BFS
+	int q_count = q.size(); // initialize queue size
+	while (!q.empty()) {
+		pair<int, pair<int, int>> t = q.front();
+		for (int i = 0; i < 6; i++) {
+			if (box[t.first - dir[i][0]][t.second.first - dir[i][1]][t.second.second - dir[i][2]] == 1) {
+				box[t.first - dir[i][0]][t.second.first - dir[i][1]][t.second.second - dir[i][2]] = 2;
+				q.push(pair<int, pair<int, int>>(t.first - dir[i][0],
+					pair<int, int>(t.second.first - dir[i][1], t.second.second - dir[i][2])));
+				ripe++;
+			}
+		}
+		q.pop();
+		q_count--;
+		if (q_count == 0) { // next day
+			q_count = q.size();
+			day++;
+		}
+	}
+
+
+	if (num_tomatoes == ripe) {
+		cout << --day; // minus last day
+	}
+	else {
+		cout << -1;
+	}
+	
+	//print_tomatoes(); 
+}
+
+void print_tomatoes() {
+	for (int i = 0; i < H + 2; i++) {
+		for (int j = 0; j <= N + 1; j++) {
+			for (int k = 0; k <= M + 1; k++) {
+				cout << box[i][k][j] << ' ';
+			}
+			cout << '\n';
+		}
+		cout << '\n';
+	}
+
+	cout << num_tomatoes << '\n' << ripe << '\n' << day;
+}

--- a/src/hanabzu/BOJ_7569_토마토/main.cpp
+++ b/src/hanabzu/BOJ_7569_토마토/main.cpp
@@ -8,7 +8,7 @@
 
 using namespace std;
 
-int M, N, H, num_tomatoes, ripe = 0, day = 0;
+int M, N, H, num_tomatoes, ripe = 0, day = -1;
 int box[102][102][102]; // box[H][M][N]
 int dir[6][3] = { {1,0,0},{-1,0,0},{0,1,0},{0,-1,0},{0,0,1},{0,0,-1} };
 queue<pair<int,pair<int,int>>> q; // {H,M,N}
@@ -63,7 +63,7 @@ int main() {
 
 
 	if (num_tomatoes == ripe) {
-		cout << --day; // minus last day
+		cout << day;
 	}
 	else {
 		cout << -1;


### PR DESCRIPTION
###  Data structures

**padding한 3차원 배열**을 선언하여 사용하였습니다. 
가로, 세로, 높이의 최대가 모두 100이기 때문에 배열은 `box[102][102][102]`가 됩니다.
BFS에 필요한 방향 정보는 **xyz coordinate system** 여섯 방향으로 선언한 `dir[6][3]` 배열을 사용합니다.
queue에는 box의 tomato position을 저장하며 BFS를 진행하는데, 3차원 좌표를 저장하기 위해서 중첩 pair 자료구조를 저장하는 queue인 `queue<pair<int,pair<int,int>>>`를 선언하였습니다. 이때 **pair는 < H, < M, N>> 의 구조**를 지니게 됩니다.
처음엔 단순히 크기 3의 배열을 사용하려 했으나 메모리 등의 문제인지 빌드에 에러가  생겨서 STL의 pair class를 사용하는 것으로 변경하였습니다.
`num_tomatoes`는 H * M * N 으로, 전체 박스에 들어가는 tomato의 개수입니다. 이후 input을 받는 과정에서 빈 칸이 나올 때마다 -1 해줍니다.

---

### Input & Padding

각 원소를 받으며 box 배열에 저장하는 데, 앞서 말한 것처럼 -1로 토마토가 없는 빈 칸의 경우 `num_tomato--`를 해줍니다.
1인 이미 익은 토마토의 경우 BFS에서 사용하기 위해 queue에 현재 좌표를 push해주고, 익은 토마토의 개수를 의미하는 변수 `ripe`에 +1 해줍니다.
문제에서는 -1이 토마토가 없는 칸, 0이 익지 않은 토마토, 1이 익은 토마토로 표현되어있지만, 이렇게 input을 받아 그대로 사용하면 padding된 3차원 배열의 외곽 부분을 -1로 초기화해야합니다. 
**이 과정을 생략하기 위해서 input을 받고 난 후 각 원소에 +1을 해주어 0이 토마토가 없는 칸, 1이 익지 않은 토마토, 2를 익은 토마토로 표현하는 것으로 생각했습니다.**

---

### BFS

먼저 모든 경과된 날짜를 알기 위해 현재 queue의 size를 `q_count`라는 변수에 저장해줍니다.
이후 while문으로 **queue의 원소를 순회하며 BFS를 진행**하는데, 이때 `dir`배열을 사용합니다.
`dir`배열로 각 방향의 토마토가 익지 않았다면 익은 토마토로 바꿔주고, queue에 추가하며 `ripe++`해줍니다.
각 방향으로의 BFS가 끝나면 queue에서 삭제하고, `q_count--`하는데 이 때 `q_count == 0` 이라면 queue에 현재 추가된 토마토들은 하루 지나 새로 익은 토마토들이기 때문에 새로 `q_count`를 초기화 해주고, `day++`하여 경과된 날짜를 하루 늘려줍니다.

---

### Result

최종 출력은 `num_tomatoes`와 `ripe`를 비교하여 서로 같다면 모든 토마토가 익은 것이므로 `day`를 출력해주고, 같지 않다면 일부분은 익지 못했으므로 -1을 출력합니다.