### PR TITLE
Create: BOJ 7569 토마토 source code

### DIFF
--- a/src/leejaeyeong/완전탐색, dfs, bfs/BOJ_7569_토마토.java
+++ b/src/leejaeyeong/완전탐색, dfs, bfs/BOJ_7569_토마토.java
@@ -1,0 +1,81 @@
+package date0629;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class BOJ_7569_토마토 {
+	static int h, n, m, ripe, unripe;
+	static int[][][] box;
+	static boolean[][][] visited;
+	static Queue<int[]> que = new LinkedList<>();
+	static int[] dz = { 0, 0, 0, 0, 1, -1 };
+	static int[] dy = { 1, -1, 0, 0, 0, 0};
+	static int[] dx = { 0, 0, -1, 1, 0, 0 };
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		m = stoi(st.nextToken());
+		n = stoi(st.nextToken());
+		h = stoi(st.nextToken());
+		box = new int[h][n][m];
+		visited = new boolean[h][n][m];
+		
+		// 초기 상자의 상태 input
+		for (int i = 0; i < h; i++) {
+			for (int j = 0; j < n; j++) {
+				st = new StringTokenizer(br.readLine());
+				for (int k = 0; k < m; k++) {
+					box[i][j][k] = stoi(st.nextToken());
+					if (box[i][j][k] == 1) { // 익은 토마토 
+						ripe++;
+						que.offer(new int[] {i, j, k});
+						visited[i][j][k] = true;
+					} else if(box[i][j][k] == 0) { // 익지 않은 토마토
+						unripe++;
+					}
+				}
+			}
+		}
+		if (unripe == 0) {
+			System.out.println(0);
+			return;
+		}
+		System.out.println(bfs());
+	}
+
+	private static int bfs() {
+		int day = -1, ripeCount = 0;
+		while(!que.isEmpty()) {
+			int size = que.size();
+			for (int i = 0; i < size; i++) {
+				int z = que.peek()[0];
+				int y = que.peek()[1];
+				int x = que.poll()[2]; // 익은 토마토의 좌표
+				
+				for (int k = 0; k < 6; k++) {
+					int nz = z + dz[k];
+					int ny = y + dy[k];
+					int nx = x + dx[k]; // 인접한 위치의 좌표
+					
+					if (nz < 0 || nz >= h || ny < 0 || ny >= n || nx < 0 || nx >= m) continue; // 박스 영역을 벗어나는 경우
+					if (visited[nz][ny][nx] || box[nz][ny][nx] == -1) continue; // 이미 처리했거나, 빈칸인 경우
+					
+					// 인접한 영역에 토마토가 있고, 익지 않은 경우
+					ripeCount++;
+					visited[nz][ny][nx] = true;
+					que.offer(new int[] {nz, ny, nx});
+				}
+			}
+			day++;
+		}
+		if (ripeCount != unripe) return -1;
+		return day;
+	}
+
+	private static int stoi(String s) {
+		return Integer.parseInt(s);
+	}
+}


### PR DESCRIPTION
초기에 익은 토마토의 위치를 기준으로 상태가 전파되기 때문에 해당 좌표를 Queue에 저장한 후 BFS를 수행했습니다. 
BFS를 진행하면서 박스의 **영역을 벗어난 경우**, **빈칸인 경우**, **이미 처리가 된 영역인 경우** 탐색의 의미가 없어 
더 이상 진행하지 않고 다음 반복으로 넘어가도록 작성했습니다. 토마토 상태의 전파는 일 단위로 동시에 진행되어야하므로 BFS 탐색을 시작하기 전 `int size = que.size()`와 같이 현재 시점에 Queue에 있는 요소의 개수를 저장하고 size 만큼 `poll()`을 하는 방법을 사용했습니다. size 크기 만큼의 BFS루틴을 완료하면 하루가 지난 것으로 처리하여 풀었습니다.
 