### PR TITLE
Create: BOJ_2533 사회망 서비스 (SNS)

### DIFF
--- a/src/hanabzu/BOJ_2533_사회망서비스(SNS)/main.cpp
+++ b/src/hanabzu/BOJ_2533_사회망서비스(SNS)/main.cpp
@@ -1,0 +1,54 @@
+﻿/* hanabzu */
+/* BOJ_2533 사회망 서비스 (SNS) */
+
+#include <iostream>
+#include <vector>
+using namespace std;
+
+int N, u, v;
+int parent[1000001] = { 0, };
+bool white[1000001] = { 0, };
+vector<int> e[1000001];
+
+int find_min(int n);
+
+int main() {
+	ios_base::sync_with_stdio(false);
+	cin.tie(NULL);
+	cout.tie(NULL);
+
+	cin >> N;
+	for (int i = 1; i < N; i++) {
+		cin >> u >> v;
+		e[u].push_back(v);
+		e[v].push_back(u);
+	}
+
+	parent[1] = -1;
+	cout << find_min(1);
+
+	return 0;
+}
+
+int find_min(int n) {
+	int cost = 0;
+
+	white[n] = 1; // it has a chance to be white
+
+	for (vector<int>::iterator it = e[n].begin(); it != e[n].end(); it++) {
+		if (parent[*it] == 0) { // first found
+			parent[*it] = n;
+		}
+		if (*it != parent[n]) {
+			cost += find_min(*it); // DFS
+			if (white[n]) {
+				if (white[*it]) { // any white child exists, it turns to black
+					white[n] = 0;
+					cost++;
+				}
+			}
+		}
+	}
+
+	return cost;
+}


### PR DESCRIPTION
## DFS

root node는 무엇으로 잡아도 상관없으므로 1로 잡고, root node의 각 child node가 root인 subtree의 minimum cost를 구해서 모두 더하는 방식으로 recursive하게 최종 cost를 구합니다.
이 때 parent node의 child node들이 모두 black이면 (얼리어답터이면) parent node는 white여도 됩니다.
그러나 child node 중 하나라도 white라면, parent node는 black이어야 합니다. (그러므로 cost는 1 증가합니다.)
이러한 white 판단은 `bool white[1000001]` 배열로 합니다.
parent node의 cost를 더하는 것을 막기 위해  `int parent[1000001]` 배열로 parent node를 저장하여, child node들의 cost를 더할 때 고려해줍니다. (root node인 1의 parent는 -1로 두어 예외로 처리합니다.)

처음엔 계속 시간초과가 났었는데, adjacent list를 `map<int, vector<int>>` 자료구조에 저장했기 때문이었고 그냥 `vector<int>`의 배열로 바꾸자 통과했습니다.
