### PR TITLE
Create: BOJ 2533 사회망 서비스 source code

### DIFF
--- a/src/leejaeyeong/완전탐색, dfs, bfs/BOJ_2533_사회망_서비스.java
+++ b/src/leejaeyeong/완전탐색, dfs, bfs/BOJ_2533_사회망_서비스.java
@@ -31,33 +31,23 @@ public class BOJ_2533_사회망_서비스 {
 		}
 		
 		treeSearch(1); // 1번 노드부터 탐색
-		int answer = 0;
-		for (int i = 1; i <= n; i++) {
-			if (earlyAdopter[i]) { // 얼리어답터 수 카운트
-				++answer;
-			}
-		}
-		System.out.println(answer);
+		System.out.println(count);
 	}
 	
 	
-	private static boolean treeSearch(int root) {
+	private static void treeSearch(int root) {
 		visited[root] = true;
 		
-		if (tree[root].isEmpty()) { // 단말노드인 경우 
-			return true; 
-		}
-		
 		for (int node : tree[root]) {
-			if (!visited[node]) { // 아직 처리하지 않은 경우 
-				if (treeSearch(node) || !earlyAdopter[node]) { // node가 단말 노드이거나, 얼리어답터가 아닌 경우
+			if (!visited[node]) { // 아직 처리하지 않은 경우
+				treeSearch(node);
+				if (!earlyAdopter[node] && !earlyAdopter[root]) { // node가 단말 노드이거나, 얼리어답터가 아닌 경우
 					earlyAdopter[root] = true; // 부모 노드를 얼리어답터로 처리
+					count++;
 				} 
 			}
 		}
-		return false;
 	}
-
 
 	private static int stoi(String s) {
 		return Integer.parseInt(s);

--- a/src/leejaeyeong/완전탐색, dfs, bfs/BOJ_2533_사회망_서비스.java
+++ b/src/leejaeyeong/완전탐색, dfs, bfs/BOJ_2533_사회망_서비스.java
@@ -1,0 +1,65 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class BOJ_2533_사회망_서비스 {
+	static int count;
+	static List<Integer>[] tree;
+	static boolean[] earlyAdopter, visited;
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		
+		int n = stoi(br.readLine());
+		tree = new ArrayList[n + 1];
+		earlyAdopter = new boolean[n + 1]; // 얼리어답터 목록
+		visited = new boolean[n + 1];
+		
+		// 트리 구성
+		for (int i = 1; i <= n; i++) {
+			tree[i] = new ArrayList<>();
+		}
+		
+		for (int i = 0; i < n - 1; i++) {
+			st = new StringTokenizer(br.readLine());
+			int u = stoi(st.nextToken());
+			int v = stoi(st.nextToken());
+			tree[u].add(v);
+			tree[v].add(u);
+		}
+		
+		treeSearch(1); // 1번 노드부터 탐색
+		int answer = 0;
+		for (int i = 1; i <= n; i++) {
+			if (earlyAdopter[i]) { // 얼리어답터 수 카운트
+				++answer;
+			}
+		}
+		System.out.println(answer);
+	}
+	
+	
+	private static boolean treeSearch(int root) {
+		visited[root] = true;
+		
+		if (tree[root].isEmpty()) { // 단말노드인 경우 
+			return true; 
+		}
+		
+		for (int node : tree[root]) {
+			if (!visited[node]) { // 아직 처리하지 않은 경우 
+				if (treeSearch(node) || !earlyAdopter[node]) { // node가 단말 노드이거나, 얼리어답터가 아닌 경우
+					earlyAdopter[root] = true; // 부모 노드를 얼리어답터로 처리
+				} 
+			}
+		}
+		return false;
+	}
+
+
+	private static int stoi(String s) {
+		return Integer.parseInt(s);
+	}
+}	


### PR DESCRIPTION
root 노드(1번 노드)를 시작으로 **dfs 탐색**을 이용해 문제를 풀었습니다. 
문제를 단순하게 생각했을 때, 부모 노드와 자식 노드 중 **부모 노드를 얼리어답터로 선택하는 것이 유리합니다.** 
(자식 노드를 얼리어답터로 선택할 경우 부모 노드의 또 다른 자식 노드에 대해서 같은 처리를 해줘야하므로 최소가 되지 않음)
사회망 서비스 조건이 만족되기 위해서는 자신과 연결된 모든 노드가 얼리어답터여야 한다는 조건을 만족해야 하기 때문에 자식 노드가 얼리어답터가 아닐 경우 부모 노드는 반드시 얼리어답터가 되어야합니다.  

1. 자식 노드가 단말 노드일 때 부모 노드를 얼리어답터로 설정
2. 자식 노드가 얼리어답터가 아닐 경우 부모 노드를 얼리어답터로 설정
3. 선택된 얼리어답터의 개수를 카운팅하여 출력
