### PR TITLE
Create: BOJ_9207_페그 솔리테어 Code

### DIFF
--- a/src/ashpurple/BOJ_9207_페그 솔리테어/Main.java
+++ b/src/ashpurple/BOJ_9207_페그 솔리테어/Main.java
@@ -1,0 +1,113 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+public class Main {
+	
+	static int N;
+	static char[][] board;
+	static int minPin, minMove;
+	static int curPin, curMove;
+	static int row = 5, col = 9;
+	static int[] dx = {1, 0, -1, 0};
+	static int[] dy = {0, 1, 0, -1};
+
+	public static void main(String[] args) throws Exception {
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		
+		/* input */
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = stoi(st.nextToken());
+		
+		for(int t = 0; t < N; t++) {
+			curPin = 0;
+			curMove = 0;
+			
+			board = new char[row][col];
+			for(int i = 0; i < row; i++) {
+				String line = br.readLine();
+				for(int j = 0; j < col; j++) {
+					board[i][j] = line.charAt(j);
+					if(board[i][j] == 'o')
+						curPin++;
+				}
+			}
+			
+			minPin = curPin;
+			
+			dfs();
+		
+			/* output */
+			bw.write(minPin + " " + minMove + "\n");
+			bw.flush();
+			
+			if(t != N-1)
+				br.readLine();
+		}
+		bw.close();
+	}
+	
+	static boolean isValid(int x1, int y1, int x2, int y2) {
+		if(x1 >= 0 && y1 >= 0 && x1 < row && y1 < col) {
+			if(board[x1][y1] == 'o') { // has adjacent pin
+				if(x2 >= 0 && y2 >= 0 && x2 < row && y2 < col) {
+					if(board[x2][y2] == '.') // can jump
+						return true;
+				}
+			}
+		}
+		return false;
+	}
+	
+	static void dfs(){
+		
+		for(int x = 0; x < row; x++) {
+			for(int y = 0; y < col; y++) {
+				
+				if(board[x][y] == 'o') {
+					
+					for(int dir = 0; dir < 4; dir++) {
+						int x1 = x + dx[dir]; // move one space
+						int y1 = y + dy[dir];
+						int x2 = x1 + dx[dir]; // move two space
+						int y2 = y1 + dy[dir];
+						
+						if(isValid(x1, y1, x2, y2)) { // can remove pin
+							board[x][y] = '.';
+							board[x1][y1] = '.';
+							board[x2][y2] = 'o';
+							curPin--;
+							curMove++;
+							
+							dfs();
+							
+							board[x][y] = 'o';
+							board[x1][y1] = 'o';
+							board[x2][y2] = '.';
+							curPin++;
+							curMove--;
+						}
+					}
+				}
+			}
+		}
+		
+		// update minimum value
+		if(curPin < minPin) { 
+			minPin = curPin;
+			minMove = curMove;
+		}
+		else if(curPin == minPin && curMove < minMove) {
+			minMove = curMove;
+		}
+    }
+	
+	private static int stoi(String s) {
+		return Integer.parseInt(s);
+	}
+}
+


### PR DESCRIPTION
DFS를 이용해 특정 조건을 만족 하는 경우에만 다음 노드를 재귀적으로 호출하는 방법을
3중 for문을 이용한 완전 탐색으로 구현하였습니다.

1. pin이 존재할 때  jump가 가능한지 체크
-> `isValid()` : 한칸 이동 방향에 핀이 존재, 두칸 이동 방향에 빈칸, 두 이동에 대한 range 유효
2. 유효하다면 jump 후 바뀐 게임판을 반영한 뒤 `curPin` (현재 핀의 개수) 와 `curMove` (현재 이동 횟수) 업데이트
-> `curPin` 1 감소, `curMove` 1 증가
3. 바뀐 게임판 상태에서 다시 `dfs()` 호출
-> 다음노드(점프 시행 후 경우의 수) 호출
4. 게임판과 `curPin` `curMove` 모두 원상 복귀
-> 다른 자식 노드에 대한 종속성 제거
5. 만약 `curPin`이 `minPin`(최솟값) 보다 작다면 `minPin`과 `minMove `업데이트

바뀐 게임판에 대한 정보를 인자로 넘겨주어 원상 복귀 과정을 생략할 수 있지만
인자를 넘겨줄 때의 배열 복사 과정이 원상복귀 과정보다 훨씬 길다고 생각되어
`dfs()`에는 인자를 주지않고 전역변수로만 처리하였습니다.