### PR TITLE
Create: BOJ_2352 반도체 설계 Code

### DIFF
--- a/src/ashpurple/BOJ_2352_반도체 설계/Main.java
+++ b/src/ashpurple/BOJ_2352_반도체 설계/Main.java
@@ -1,0 +1,69 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+	static int[] lastArr, arr;
+	static int N;
+
+	public static void main(String[] args) throws Exception {
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		
+		/* input */
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = stoi(st.nextToken());
+		arr = new int[N];
+		lastArr = new int[N]; // dp[i] = smallest last number of i_length LIS
+		
+		st = new StringTokenizer(br.readLine());
+		for(int i = 0; i < N; i++) {
+			arr[i] = stoi(st.nextToken());
+		}
+		
+		int len = 0;
+		lastArr[0] = arr[0];
+		for(int i = 1; i < N; i++) {
+			if(lastArr[len] < arr[i]) 
+				lastArr[++len] = arr[i];
+			else {
+				int idx = lowerBound(arr[i], len);
+				lastArr[idx] = arr[i];
+			}
+
+		}
+		
+		/* output */
+		String result = String.valueOf(len + 1);
+		bw.write(result);
+		bw.flush();
+		bw.close();
+	}
+	
+	private static int lowerBound(int target, int len) {
+	    int begin = 0;
+	    int end = len;
+	    
+	    while(begin < end) {
+	    	int mid = (begin + end) / 2;
+	        
+	        if(lastArr[mid] >= target) {
+	        	end = mid;
+	        }
+	        else {
+	        	begin = mid + 1;
+	        }
+	    }
+	    return end;
+	}
+		
+	
+	private static int stoi(String s) {
+		return Integer.parseInt(s);
+	}
+}
+


### PR DESCRIPTION
### Lower Bound를 활용한 LIS

일반적인 dp를 활용한 LIS 풀이를 이용하면 `O(N^2)` 의 시간복잡도를 가진다.
하지만 문제에서 n의 범위는 40000만까지이므로 해당 풀이는 시간초과가 발생한다.

문제의 핵심은 해당 조건을 만족하는 최장 증가 부분수열을 구하는 것이 아니라 그 **수열의 길이**를 구하는 것에 있다.
알고리즘은 다음과 같다.

자료구조
- `lastArr[i]` : 길이가 i인 증가수열에서 마지막 값의 최소 값
- `len` : lastArr의 길이 (마지막 index)

알고리즘
1. 첫번째 원소를 `lastArr`에 넣어주고 길이를  0으로 초기화한다.
2. `lastArr`이 비교값 보다 작다면 길이를 1 증가시키고 비교값을 끝에 삽입한다.
3. `lastArr`이 비교값 보다 크다면 `lowerBound`를 이용해  비교값을 `lastArr` 내부 값과 바꾼다. (이때 길이는 유지된다)
4. 마지막 비교값까지 반복문이 종료되면 lastArr의 길이가 LIS의 길이가 된다.

이 방법은 이진탐색을 n번 수행하므로 `O(N*lgN)`의 시간복잡도를 가진다
단 `lastArr`의 값들은 길이가 다른 LIS들의 last min 값이므로 LIS 값과 무관하다. 즉 해당 배열은 길이만 사용한다.

해당 내용은 LIS 알고리즘을 다룬 [개인 블로그](https://shoark7.github.io/programming/algorithm/3-LIS-algorithms)를 참고하여 공부했다. 알고리즘의 자세한 원리는 링크에서 확인 가능하다.
